### PR TITLE
Fix an issue with AllRequest max ignoring -1 unlimited.

### DIFF
--- a/src/main/java/com/serverjars/api/JarDetails.java
+++ b/src/main/java/com/serverjars/api/JarDetails.java
@@ -3,7 +3,6 @@ package com.serverjars.api;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 /**
  * @author Jacobtread

--- a/src/main/java/com/serverjars/api/request/AllRequest.java
+++ b/src/main/java/com/serverjars/api/request/AllRequest.java
@@ -38,7 +38,7 @@ public class AllRequest implements Request<AllResponse> {
 
     @Override
     public String url() {
-        return "/fetchAll/" + type + (max > 0 ? "/" + max : "");
+        return "/fetchAll/" + type + "/" + max;
     }
 
     @Override

--- a/src/main/java/com/serverjars/api/request/Request.java
+++ b/src/main/java/com/serverjars/api/request/Request.java
@@ -2,7 +2,6 @@ package com.serverjars.api.request;
 
 import com.google.gson.JsonObject;
 import com.serverjars.api.Response;
-import com.serverjars.api.ServerJars;
 
 /**
  * @author Jacobtread


### PR DESCRIPTION
When sending an AllRequest with -1 as the max, the ternary used in the url format would deny any number below 0.

Also clean some unused imports.